### PR TITLE
BLD: added anchors to table rows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -75,3 +75,8 @@ code {
 label {
   margin-left: 5px;
 }
+
+.anchor {
+    position: absolute;
+    margin-top: -80px
+}

--- a/src/index.js
+++ b/src/index.js
@@ -206,10 +206,12 @@ function ListItem(props){
       license = <a href={item.license[j].licenseURL} target="_blank" rel="noopener noreferrer">{item.license[j].spdx} </a>
     }
 
+    let linkName = item.name.replace(/ /g,'_')
+
 	return(
 		<tr key={index} className={itemClass}>
 			<td>{name}</td>
-			<td>{item.description}</td>
+			<td><a id={linkName} className="anchor"></a>{item.description}</td>
 			<td>{license}</td>
 			<td><div dangerouslySetInnerHTML={{__html: item.githubActivity}} /></td>
 		</tr>


### PR DESCRIPTION
Fixes #1.

Since the description field can be multiline and change the amount of space that rows occupies, the anchor is set on that field, rather than the name. An `anchor` CSS class has been added to add a top margin to compensate for the sticky header, otherwise the linked row would be hidden behind the header. This CSS fix is explained in this StackOverflow question: [sticky header internal links](https://stackoverflow.com/questions/7717894/sticky-header-internal-links)