### PR TITLE
Fix viewbox of distribution by SDG treemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ var width = 960, height = 500;
 var svg = d3.select("#treemap")
 .append("svg")
   .attr("preserveAspectRatio", "xMinYMin meet")
-  .attr("viewBox", "0 0 1000 300")
+  .attr("viewBox", "0 0 " + width + " " + height)
 `
 htmlOutput += 'var data_sdg = '+JSON.stringify(sdgData)+';';
 htmlOutput += 'var data_type = '+JSON.stringify(typeData)+';';


### PR DESCRIPTION
Now the viewBox of the treemap is equal to its width and height.
@lacabra kindly take a look at this PR

**Before**
![before](https://user-images.githubusercontent.com/44370635/116461461-f2e79980-a870-11eb-860c-b2334820f0ce.PNG)


**After**
![after](https://user-images.githubusercontent.com/44370635/116461434-eb27f500-a870-11eb-88b1-4e619b61b57f.PNG)

Closes #10 