### PR TITLE
Fix displaying 17 sdg in Data visualization

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ glob(path + '/*.json', {}, async (err, files) => {
   }
   let combos = [0,0,0,0,0,0,0,0,0,0,0,0,0,0]
   // Initialize SDG array to count occurences in candidates
-  let sdgs = new Array(17).fill(0);
+  let sdgs = new Array(18).fill(0);
   // Initialize type array to count occurences in candidates
   const TYPE1='software';
   const TYPE2='data';
@@ -280,7 +280,7 @@ textLine.each(function (d) {
     }
     // push value to last line
     textLines.length == 0 
-      ? rectHeight < lineHeight && textLines.push(": " + d.data.value)
+      ? rectHeight < lineHeight && rectWidth - offset - 10 > textLenght(this, ": " + d.data.value) && textLines.push(": " + d.data.value)
       : textLines.push(d.data.value);
     textLines.length == 0 
       ? rectHeight > lineHeight && textLines.push(":", d.data.value)

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ glob(path + '/*.json', {}, async (err, files) => {
   }
   let combos = [0,0,0,0,0,0,0,0,0,0,0,0,0,0]
   // Initialize SDG array to count occurences in candidates
-  let sdgs = new Array(18).fill(0);
+  let sdgs = new Array(17).fill(0);
   // Initialize type array to count occurences in candidates
   const TYPE1='software';
   const TYPE2='data';
@@ -71,7 +71,7 @@ glob(path + '/*.json', {}, async (err, files) => {
   // Iterate over candidates, and over each nested array and count
   candidates.forEach(function(e) {
     e['SDGs'].forEach(function(d){
-      sdgs[d['SDGNumber']]++;
+      sdgs[d['SDGNumber']-1]++;
     })
     e['type'].forEach(function(d){
       types[d]++;
@@ -100,7 +100,7 @@ glob(path + '/*.json', {}, async (err, files) => {
   let sdgData = { name: 'SDGs', children: []};
   for(let i=0; i < sdgs.length; i++) {
     if (sdgs[i]) {
-      sdgData['children'].push({name: i, value: sdgs[i]});
+      sdgData['children'].push({name: i+1, value: sdgs[i]});
     }
   }
 


### PR DESCRIPTION
The problem was in iterations over sdg data. SDGs array contains [0-16] indexes so `sdgs[d['SDGNumber']]++;` failed in sdgs[17].
Fastest approach is to add 1 more cell in array so check in `102 line` do the rest.
I also fixed minor bug with displaying value in `14` sdg which doesn't fit both vertically and horizontally.

**Before**
![before](https://user-images.githubusercontent.com/44370635/117001860-898ddd80-aceb-11eb-8cee-3e6cedd269b4.PNG)
**After**
![after](https://user-images.githubusercontent.com/44370635/117001866-8abf0a80-aceb-11eb-8ef9-bb0e610fcc6b.PNG)

@lacabra kindly check this PR. Do I need to change anything?
Closes #13 