### PR TITLE
Fix issue #29 and include "May be eligible" result

### DIFF
--- a/packages/eligibility/src/Eligibility.js
+++ b/packages/eligibility/src/Eligibility.js
@@ -105,12 +105,10 @@ function Eligibility() {
     let maybeList = [];
 
     while (i < 9) {
-      if((i===3 || i===5) && answersList[i] === "No") {
+      if(answersList[i] === quizQuestions[i].answer) {
         scoreValue += 1;
-      } else if ((i===3 || i===5) && answersList[i] === "Yes") {
+      } else if (answersList[i] !== quizQuestions[i].answer && quizQuestions[i].maybe) {
         maybeList.push(quizQuestions[i]);
-      } else if(i!==3 && i!==5 && answersList[i] === "Yes") {
-        scoreValue += 1;
       } else {
         questionsList.push(quizQuestions[i]);
       }

--- a/packages/eligibility/src/Eligibility.js
+++ b/packages/eligibility/src/Eligibility.js
@@ -121,10 +121,10 @@ function Eligibility() {
     setWrongQuestions(questionsList);
     setMaybeQuestions(maybeList); 
 
-    if(scoreValue === quizQuestions.length) {
+    if(scoreValue === quizQuestions.length || scoreValue + maybeList.length === quizQuestions.length) {
       setButtonName("Proceed");
       setResultClick(true);
-    } else if (scoreValue < 9) {
+    } else {
       setButtonName("Start Again")
       setResultClick(false);
     }

--- a/packages/eligibility/src/Eligibility.js
+++ b/packages/eligibility/src/Eligibility.js
@@ -17,6 +17,7 @@ function Eligibility() {
   const [score, setScore] = useState(0);
   const [buttonName, setButtonName] = useState('');
   const [wrongQuestions, setWrongQuestions] = useState([]);
+  const [maybeQuestions, setMaybeQuestions] = useState([]);
   const [resultClick, setResultClick] = useState(null);
 
   React.useEffect(() => {
@@ -101,16 +102,25 @@ function Eligibility() {
     let i = 0;
     let scoreValue = 0;
     let questionsList = [];
+    let maybeList = [];
+
     while (i < 9) {
-      if(answersList[i] === "Yes") {
+      if((i===3 || i===5) && answersList[i] === "No") {
         scoreValue += 1;
-      } else if(answersList[i] === "No") {
+      } else if ((i===3 || i===5) && answersList[i] === "Yes") {
+        maybeList.push(quizQuestions[i]);
+      } else if(i!==3 && i!==5 && answersList[i] === "Yes") {
+        scoreValue += 1;
+      } else {
         questionsList.push(quizQuestions[i]);
       }
       i += 1;
     }
+
     setScore(scoreValue);
     setWrongQuestions(questionsList);
+    setMaybeQuestions(maybeList); 
+
     if(scoreValue === quizQuestions.length) {
       setButtonName("Proceed");
       setResultClick(true);
@@ -162,7 +172,7 @@ function Eligibility() {
 
         {counter === quizQuestions.length && (
           <>
-          <Result quizScore={score} result={answersList} questions={wrongQuestions} />
+          <Result quizScore={score} result={answersList} questions={wrongQuestions} maybeQuestions={maybeQuestions} />
           <div className="text-center">
             <Button 
               className="ml-2"

--- a/packages/eligibility/src/api/quizQuestions.js
+++ b/packages/eligibility/src/api/quizQuestions.js
@@ -142,7 +142,7 @@ var quizQuestions = [
     }
   },
   {
-    question: "Does the project do no harm?",
+    question: "Does the project take steps to anticipate, prevent and do no harm?",
     statement: "All projects must demonstrate that they have taken steps to ensure the project anticipates, prevents, and does no harm.",
     faq: {
       copy: [

--- a/packages/eligibility/src/api/quizQuestions.js
+++ b/packages/eligibility/src/api/quizQuestions.js
@@ -3,6 +3,8 @@ import React from 'react';
 var quizQuestions = [
   {
       question: "Is the project relevant to one of the Sustainable Development Goals?",
+      answer: "Yes",
+      maybe: false,
       statement: "Projects must demonstrate relevance to SDGs",
       faq: {
               copy: [
@@ -21,6 +23,8 @@ var quizQuestions = [
   },
   {
       question: "Does it use an appropriate open license?",
+      answer: "Yes",
+      maybe: false,
       statement: "Projects must demonstrate the use of an approved open license.",
       faq: {
           copy: [
@@ -50,6 +54,8 @@ var quizQuestions = [
   },
   {
       question: "Is ownership clearly defined?",
+      answer: "Yes",
+      maybe: false,
       statement: "Ownership of everything the project produces must be clearly defined and documented.",
       faq: {
         copy: [
@@ -64,6 +70,8 @@ var quizQuestions = [
   },
   {
       question: "Does the license of libraries/ dependencies undermine the openess of the project?",
+      answer: "No",
+      maybe: true,
       statement: "If the project has mandatory dependencies that create more restrictions than the original license, the project(s) must be able to demonstrate independence from the closed component(s) and/or indicate the existence of functional, open alternatives.",
       faq: {
         copy: [
@@ -82,6 +90,8 @@ var quizQuestions = [
   },
   {
       question: "Is there documentation?",
+      answer: "Yes",
+      maybe: false,
       statement: "The project must have documentation of the source code, use cases, and/or functional requirements.",
       faq: {
         copy: [
@@ -96,6 +106,8 @@ var quizQuestions = [
   },
   {
     question: "Does this project collect or use non-personally identifiable information (non-PII) data?",
+    answer: "No",
+    maybe: true,
     statement: "If the project has non personally identifiable information (PII) there must be a mechanism for extracting or importing non-PII data from the system in a non-proprietary format.",
     faq: {
       copy: [
@@ -114,6 +126,8 @@ var quizQuestions = [
   },
   {
     question: "Does the project adhere to privacy and other applicable international and domestic laws?",
+    answer: "Yes",
+    maybe: false,
     statement: "The project must state to the best of its knowledge that it complies with relevant privacy laws, and all applicable international and domestic laws.",
     faq: {
       copy: [
@@ -128,6 +142,8 @@ var quizQuestions = [
   },
   {
     question: "Does the project adhere to standards and best practices?",
+    answer: "Yes",
+    maybe: false,
     statement: "Projects must demonstrate adherence to standards, best practices, and/or principles.",
     faq: {
       copy: [
@@ -143,6 +159,8 @@ var quizQuestions = [
   },
   {
     question: "Does the project take steps to anticipate, prevent and do no harm?",
+    answer: "Yes",
+    maybe: false,
     statement: "All projects must demonstrate that they have taken steps to ensure the project anticipates, prevents, and does no harm.",
     faq: {
       copy: [

--- a/packages/eligibility/src/components/Result.js
+++ b/packages/eligibility/src/components/Result.js
@@ -16,7 +16,30 @@ function Result(props) {
       </>
     )}
 
-    {props.quizScore < 9 && (
+    {props.quizScore < 9 && props.questions.length === 0 && props.maybeQuestions.length > 0 && (
+      <>
+      <h2 className="text-center"> You may be eligible! </h2>
+      <div className="pt-3 pl-5 pr-4 pb-4" style={{fontFamily:'Jost-light'}}>
+        You correctly answered <strong>{props.quizScore}/9</strong> in the Eligibility Test. You may be eligible to nominate
+        your project to DPG based on the conditions given below. 
+      </div>
+      <div className="summary">    
+          
+          {props.maybeQuestions.map((object, index) => (
+              <Summary
+                key={index}
+                index={index}
+                statement={props.maybeQuestions[index].statement}
+                name={props.maybeQuestions[index].faq.name}
+                link={props.maybeQuestions[index].faq.link}
+              />
+          ))}
+
+      </div>
+      </>
+    )}
+
+    {props.quizScore < 9 && props.questions.length > 0 && (
       <>
       <h2 className="text-center"> Sorry! You are not eligible. </h2>
       <div className="pt-3 pl-4 pr-4 pb-4">
@@ -34,6 +57,23 @@ function Result(props) {
                 link={props.questions[index].faq.link}
               />
           ))}
+
+          {props.maybeQuestions.length > 0 && (
+            <>
+            <div className="pl-5 pr-5 pt-4" style={{fontSize:20, textAlign:"left"}}>
+              Furthermore,
+            </div>
+            {props.maybeQuestions.map((object, index) => (
+                <Summary
+                  key={index}
+                  index={index}
+                  statement={props.maybeQuestions[index].statement}
+                  name={props.maybeQuestions[index].faq.name}
+                  link={props.maybeQuestions[index].faq.link}
+                />
+            ))}
+            </>
+          )}
               
       </div>
       </>


### PR DESCRIPTION
The pull request fixes #29.

- Takes correct answer as `No` in questions 4 and 6.
- If `Yes` is selected in questions 4 and 6, the user may be eligible if certain conditions are met.

Please note the following workflows:

- If 9/9 correct completely -> Page A (You are eligible)
- If at least 1 wrong completely and no maybes --> Page B (You are not eligible)
- If at least 1 wrong completely and at least 1 maybe --> Page B (Includes a "Furthermore" for the maybe question)
- If none wrong and at least 1 maybe --> Page C (You may be eligible given the conditions below)