### PR TITLE
Resolve issue in passing initial state 

### DIFF
--- a/packages/eligibility/src/Eligibility.js
+++ b/packages/eligibility/src/Eligibility.js
@@ -36,7 +36,7 @@ function Eligibility() {
     return () => {
       document.removeEventListener('keydown', handleKeys);
     };
-  }, []);
+  });
 
   const debounce = (func, wait) => {
     let timeout;
@@ -114,6 +114,7 @@ function Eligibility() {
       setButtonName('');
       setWrongQuestions([]);         
     } else if (param) {
+      debouncedSave(values);
       window.open("https://submission-digitalpublicgoods.vercel.app/");
     }
   }


### PR DESCRIPTION
This fixes an important issue that was raised due to #34. 
The `debouncedSave()` function is not being called when the `Proceed` button is clicked. This also removes other warnings shown during the build. 