### PR TITLE
MAINT: updated submission form domain

### DIFF
--- a/packages/eligibility/README.md
+++ b/packages/eligibility/README.md
@@ -1,6 +1,6 @@
 # Eligibility Form
 
-The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) consists of nine questions that will help users quickly determine if their digital solution can be nominated as a Digital Public Good (DPG) at this time. If the digital solution is eligible, the user may continue with their nomination submission via the [submission form](https://submission-digitalpublicgoods.vercel.app/). If the digital solution is not currently eligible, the user will be given pointers on how they can improve the product in order to make it eligible. 
+The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) consists of nine questions that will help users quickly determine if their digital solution can be nominated as a Digital Public Good (DPG) at this time. If the digital solution is eligible, the user may continue with their nomination submission via the [submission form](https://submission.digitalpublicgoods.net/). If the digital solution is not currently eligible, the user will be given pointers on how they can improve the product in order to make it eligible.
 
 If you want to know whether your favorite open, social impact project can become a DPG, we welcome you to fill out this quick and easy form. 
 

--- a/packages/eligibility/src/components/Eligibility.js
+++ b/packages/eligibility/src/components/Eligibility.js
@@ -63,7 +63,7 @@ function Eligibility() {
 
   async function saveToDb(vals) {
     if (cookies.uuid) {
-      await fetch(`https://submission-digitalpublicgoods.vercel.app/api/saveDB/${cookies.uuid}`, {
+      await fetch(`https://submission.digitalpublicgoods.net/api/saveDB/${cookies.uuid}`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -136,7 +136,7 @@ function Eligibility() {
       setIsOwner(true);        
     } else if (param) {
       debouncedSave(values);
-      window.open("https://submission-digitalpublicgoods.vercel.app/");
+      window.open("https://submission.digitalpublicgoods.net/");
     }
   }
 


### PR DESCRIPTION
Fix #49 

In order for CORS to work as intended, we have to use the same domain between both forms, that is `digitalpublicgoods.net`. Up until now, we were calling the form at `submission-digitalpublicgoods.vercel.app` which is on a different domain.