### PR TITLE
Update number of questions in Eligibility Form

### DIFF
--- a/packages/eligibility/src/api/quizQuestions.js
+++ b/packages/eligibility/src/api/quizQuestions.js
@@ -56,7 +56,8 @@ var quizQuestions = [
       question: "Is ownership clearly defined?",
       answer: "Yes",
       maybe: false,
-      fieldName: "clearOwnership[isOwnershipExplicit]",
+      fieldName: "clearOwnership",
+      keyName: "isOwnershipExplicit",
       statement: "Ownership of everything the digital solution produces must be clearly defined and documented.",
       faq: {
         copy: [
@@ -73,7 +74,8 @@ var quizQuestions = [
       question: "Is the digital solution platform-independent?",
       answer: "Yes",
       maybe: true,
-      fieldName: "platformIndependence[mandatoryDepsCreateMoreRestrictions]",
+      fieldName: "platformIndependence",
+      keyName: "mandatoryDepsCreateMoreRestrictions",
       statement: "If the digital solution has mandatory dependencies that create more restrictions than the original license, the digital solution(s) must be able to demonstrate independence from the closed component(s) and/or indicate the existence of functional, open alternatives.",
       faq: {
         copy: [
@@ -97,7 +99,8 @@ var quizQuestions = [
       question: "Is there documentation of the source code, use cases, and/or functional requirements for this digital solution?",
       answer: "Yes",
       maybe: false,
-      fieldName: "documentation[isDocumentationAvailable]",
+      fieldName: "documentation",
+      keyName: "isDocumentationAvailable",
       statement: "The digital solution must have documentation of the source code, use cases, and/or functional requirements.",
       faq: {
         copy: [
@@ -114,7 +117,8 @@ var quizQuestions = [
     question: "Does this digital solution collect or use non-personally identifiable information (non-PII) data?",
     answer: "No",
     maybe: true,
-    fieldName: "NonPII[collectsNonPII]",
+    fieldName: "NonPII",
+    keyName: "collectsNonPII",
     statement: "If the digital solution has non personally identifiable information (PII) there must be a mechanism for extracting or importing non-PII data from the system in a non-proprietary format.",
     faq: {
       copy: [
@@ -138,7 +142,8 @@ var quizQuestions = [
     question: "Does the digital solution adhere to privacy and other applicable international and domestic laws?",
     answer: "Yes",
     maybe: false,
-    fieldName: "privacy[isPrivacyCompliant]",
+    fieldName: "privacy",
+    keyName: "isPrivacyCompliant",
     statement: "The digital solution must state to the best of its knowledge that it complies with relevant privacy laws, and all applicable international and domestic laws.",
     faq: {
       copy: [
@@ -155,7 +160,8 @@ var quizQuestions = [
     question: "Does the digital solution adhere to standards and best practices?",
     answer: "Yes",
     maybe: false,
-    fieldName: "standards[supportStandards]",
+    fieldName: "standards",
+    keyName: "supportStandards",
     statement: "Digital solutions must demonstrate adherence to standards, best practices, and/or principles.",
     faq: {
       copy: [
@@ -173,7 +179,9 @@ var quizQuestions = [
     question: "Does the digital solution take steps to anticipate, prevent and do no harm?",
     answer: "Yes",
     maybe: false,
-    fieldName: "doNoHarm[preventHarm[stepsToPreventHarm]]",
+    fieldName: "doNoHarm",
+    keyName: "preventHarm",
+    keyName2: "stepsToPreventHarm",
     statement: "All digital solutions must demonstrate that they have taken steps to ensure the digital solution anticipates, prevents, and does no harm.",
     faq: {
       copy: [

--- a/packages/eligibility/src/components/Eligibility.js
+++ b/packages/eligibility/src/components/Eligibility.js
@@ -170,14 +170,18 @@ function Eligibility() {
     
     while (i < 6) {
       if(i > 1) {
-        if(answersList[i] === quizQuestions[i].answer)
-          valueList[quizQuestions[i].fieldName] = quizQuestions[i].answer;
-        else {
-          if(quizQuestions[i].answer === "Yes")
-            valueList[quizQuestions[i].fieldName] = "No";
-          else
-            valueList[quizQuestions[i].fieldName] = "Yes";
+        let tempList = {};
+        if(quizQuestions[i].keyName2) {
+          let tempList2 = {};
+          tempList2[quizQuestions[i].keyName2] = answersList[i];
+          tempList[quizQuestions[i].keyName] = tempList2;
         }
+
+        else {
+          tempList[quizQuestions[i].keyName] = answersList[i];
+        }
+
+        valueList[quizQuestions[i].fieldName] = tempList;
       }
       if(answersList[i] === quizQuestions[i].answer) {
         scoreValue += 1;
@@ -215,14 +219,18 @@ function Eligibility() {
     while (i < 10) {
       if(i !== 6) {
         if(i > 1) {
-          if(answersList[i] === quizQuestions[i].answer)
-            valueList[quizQuestions[i].fieldName] = quizQuestions[i].answer;
-          else {
-            if(quizQuestions[i].answer === "Yes")
-              valueList[quizQuestions[i].fieldName] = "No";
-            else
-              valueList[quizQuestions[i].fieldName] = "Yes";
+          let tempList = {};
+          if(quizQuestions[i].keyName2) {
+            let tempList2 = {};
+            tempList2[quizQuestions[i].keyName2] = answersList[i];
+            tempList[quizQuestions[i].keyName] = tempList2;
           }
+
+          else {
+            tempList[quizQuestions[i].keyName] = answersList[i];
+          }
+
+          valueList[quizQuestions[i].fieldName] = tempList;
         }
         if(answersList[i] === quizQuestions[i].answer) {
           scoreValue += 1;

--- a/packages/eligibility/src/components/Eligibility.js
+++ b/packages/eligibility/src/components/Eligibility.js
@@ -19,7 +19,7 @@ function Eligibility() {
   const [question, setQuestion] = useState(quizQuestions[0].question);
   const [answer, setAnswer] = useState('');
   const [answersList, setAnswerList] = useState({});
-  const [score, setScore] = useState(0);
+  const [score, setScore] = useState(1);
   const [buttonName, setButtonName] = useState('');
   const [wrongQuestions, setWrongQuestions] = useState([]);
   const [maybeQuestions, setMaybeQuestions] = useState([]);
@@ -163,7 +163,7 @@ function Eligibility() {
 
   function getResultsNotOwner() {
     let i = 0;
-    let scoreValue = 0;
+    let scoreValue = 1;
     let questionsList = [];
     let maybeList = [];
     let valueList = {};
@@ -196,7 +196,7 @@ function Eligibility() {
     setMaybeQuestions(maybeList); 
     setValues(valueList);
 
-    if(scoreValue === 6 || scoreValue + maybeList.length - 3 === 6) {
+    if(scoreValue === 7 || scoreValue + maybeList.length - 3 === 7) {
       setButtonName("Proceed");
       setResultClick(true);
     } else {
@@ -207,7 +207,7 @@ function Eligibility() {
 
   function getResultsIsOwner() {
     let i = 0;
-    let scoreValue = 0;
+    let scoreValue = 1;
     let questionsList = [];
     let maybeList = [];
     let valueList = {};
@@ -239,7 +239,7 @@ function Eligibility() {
     setMaybeQuestions(maybeList); 
     setValues(valueList);
     
-    if(scoreValue === quizQuestions.length-1 || scoreValue + maybeList.length === quizQuestions.length-1) {
+    if(scoreValue === quizQuestions.length || scoreValue + maybeList.length === quizQuestions.length) {
       setButtonName("Proceed");
       setResultClick(true);
     } else {
@@ -254,7 +254,7 @@ function Eligibility() {
         <div className="pt-2 pb-3" style={{width:"60%"}}>
           <ProgressBar
             filledBackground="linear-gradient(to right, #cdbdff, #4d29ba)"
-            percent={(questionId/9)*100}
+            percent={(questionId/total)*100}
           />
         </div>
 
@@ -265,7 +265,7 @@ function Eligibility() {
           <div className="p-3">
             <h3 className="pl-3 pr-3 text-center" style={{fontFamily:"NowAlt-Regular", color:"#2b209a"}}> Is your digital solution ready to be a Digital Public Good? </h3>
             <div className="text-left p-4"> 
-            The Eligibility Form consists of 9 questions that will help you quickly determine if your digital solution can be nominated as a Digital Public Good (DPG) at this time. If your solution is eligible, you may continue with your nomination submission via the submission form. If your digital solution is not currently eligible, you will be given pointers on how you can improve it in order to make it eligible. 
+            The Eligibility Form requires you to answer 7 or 10 questions that will help you quickly determine if your digital solution can be nominated as a Digital Public Good (DPG) at this time. If your solution is eligible, you may continue with your nomination submission via the submission form. If your digital solution is not currently eligible, you will be given pointers on how you can improve it in order to make it eligible. 
             <br /><br />Want to know whether your favorite open, social impact project can become a DPG? Fill out this form and find out for yourself!
             </div>
           </div>
@@ -337,7 +337,7 @@ function Eligibility() {
 
           {startQuiz && counter === quizQuestions.length && (
             <>
-            <Result quizScore={score} total={total-1} result={answersList} questions={wrongQuestions} maybeQuestions={maybeQuestions} />
+            <Result quizScore={score} total={total} result={answersList} questions={wrongQuestions} maybeQuestions={maybeQuestions} />
             <div className="text-center">
               <Button 
                 className="ml-2"

--- a/packages/eligibility/src/components/Eligibility.js
+++ b/packages/eligibility/src/components/Eligibility.js
@@ -63,7 +63,7 @@ function Eligibility() {
 
   async function saveToDb(vals) {
     if (cookies.uuid) {
-      await fetch(`https://submission-digitalpublicgoods.vercel.app/api/saveDB/${cookies.uuid}`, {
+      await fetch(`https://submission.digitalpublicgoods.net/api/saveDB/${cookies.uuid}`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -105,7 +105,6 @@ function Eligibility() {
     if(param && !isOwner && counter===total-1) {
       getResultsNotOwner();
       setCounter(quizQuestions.length);
-      console.log("counter=" + counter);
     }
     else if (param && counter<quizQuestions.length-1) {
       setNextQuestion();      
@@ -136,7 +135,7 @@ function Eligibility() {
       setIsOwner(true);        
     } else if (param) {
       debouncedSave(values);
-      window.open("https://submission-digitalpublicgoods.vercel.app/");
+      window.open("https://submission.digitalpublicgoods.net/form?uuid=" + cookies.uuid);
     }
   }
 

--- a/packages/eligibility/src/components/Result.js
+++ b/packages/eligibility/src/components/Result.js
@@ -5,7 +5,7 @@ import Summary from './Summary'
 function Result(props) {
   return (
     <div className="result">
-    {props.quizScore === props.total && props.total === 9 && (
+    {props.quizScore === props.total && props.total === 10 && (
       <>
       <h2 className="text-center"> Your digital solution is eligible! </h2>
       <div className="pt-3 pl-4 pr-4 pb-4">


### PR DESCRIPTION
Fix #51 
The following changes have been made in this pull request:

- [x] Intro content: "You will need to answer 7 or 10 questions."
- [x] The progress bar should be set to 7 initially and then to 10 if they are the product owners. 
- [x] If they are not project owners, the summary page should say they answered 7 questions (because the last question counts)
- [x] If they are project owners, the summary page should say they answered 10 questions correctly (it’s trivial to say that the 7th question is answered correctly)
