### PR TITLE
FIX #57: add key to list childs

### DIFF
--- a/packages/eligibility/src/components/FAQ.js
+++ b/packages/eligibility/src/components/FAQ.js
@@ -6,17 +6,17 @@ function FAQ(props) {
     <div className="faq pr-5 pl-5 text-left">
       <h4 style={{fontFamily:'NowAlt-Regular', color:'#2b209a', marginBottom:20}}>Frequently Asked Questions</h4>
       {props.content.copy && props.content.copy.map((copy, index) =>
-        <>
+        <div key={index}>
           <h5 style={{fontSize:"1.1rem"}}> {copy.subHeading} </h5>
           <p style={{fontSize:"1rem", fontWeight:100, marginBottom:25}}>
             {copy.text}
           </p>
-        </>
+        </div>
       )}
 
       {props.content.link !== "" && (
         <div style={{marginTop:20, textAlign:"left"}}>
-            <h5 style={{fontSize:"1.1rem"}} class="text-uppercase"> {props.content.name} RESOURCES </h5>
+            <h5 style={{fontSize:"1.1rem"}} className="text-uppercase"> {props.content.name} RESOURCES </h5>
             <p style={{fontSize:"1rem"}}>For additional resources about {props.content.name}, please review the link below : <br></br>
             <a href={props.content.link} rel="noopener noreferrer" target="_blank">{props.content.link}</a> 
             </p>


### PR DESCRIPTION
Fix #57 by adding `key={index}` to each child in a list, and fix `className` property instead of `class` to match React nomenclature.