### PR TITLE
FIX: #59 replace p with div

### DIFF
--- a/packages/eligibility/src/components/FAQ.js
+++ b/packages/eligibility/src/components/FAQ.js
@@ -8,9 +8,9 @@ function FAQ(props) {
       {props.content.copy && props.content.copy.map((copy, index) =>
         <div key={index}>
           <h5 style={{fontSize:"1.1rem"}}> {copy.subHeading} </h5>
-          <p style={{fontSize:"1rem", fontWeight:100, marginBottom:25}}>
+          <div style={{fontSize:"1rem", fontWeight:100, marginBottom:25}}>
             {copy.text}
-          </p>
+          </div>
         </div>
       )}
 

--- a/packages/eligibility/src/components/Result.js
+++ b/packages/eligibility/src/components/Result.js
@@ -83,7 +83,7 @@ function Result(props) {
 }
 
 Result.propTypes = {
-  quizScore: PropTypes.string.isRequired,
+  quizScore: PropTypes.number.isRequired,
 };
 
 export default Result;


### PR DESCRIPTION
Fix #59.

The error occurs because certain code is wrapped with `<p>...</p>` which then inserts HTML text from `src/api/quizQuestions` which also has `<p>...</p>` in it, thus triggering an error that `<p>` cannot be a descendant of `<p>`. To preserve the current structure, the outermost `<p>` is changed to a `<div>` that can have `<p>` as children.

Also addressing the following error in commit 2e1be7d

```
index.js:1 Warning: Failed prop type: Invalid prop `quizScore` of type `number` supplied to `Result`, expected `string`.
    in Result (at Eligibility.js:348)
    in Eligibility (at src/index.js:8)
```