### PR TITLE
BUG: fix CI with no env vars

### DIFF
--- a/packages/map/pages/index.js
+++ b/packages/map/pages/index.js
@@ -208,9 +208,13 @@ export async function getStaticProps() {
     const addStory = (results) => {
       // replace all //n //r, FALSE
       for (let i = 0; i < results.length; i++) {
-        results[i].text = results[i].text.replace(/[\r\n]+/gm, " ");
-        results[i].image = results[i].image.replace("FALSE", false);
-        results[i].image = results[i].image.replace("TRUE", true);
+        if (results[i].text) {
+          results[i].text = results[i].text.replace(/[\r\n]+/gm, " ");
+        }
+        if (results[i].image) {
+          results[i].image = results[i].image.replace("FALSE", false);
+          results[i].image = results[i].image.replace("TRUE", true);
+        }
       }
       return results;
     };


### PR DESCRIPTION
Fixes an issue uncovered in #73 where the CI fails in pull_requests runs because it doesn't have access to env vars set up as secrets in this public repo for security reasons. The bug was in the code where it assumed that the request would always succeed. If we check whether the response has values or not addresses the issue without modifying the flow of the code.

Cc: @Rolikasi 