### PR TITLE
[Map] fix automation script

### DIFF
--- a/packages/automation/index.js
+++ b/packages/automation/index.js
@@ -478,7 +478,7 @@ textLine.each(function (d) {
     $('main').remove(); // removes element where map will be placed 
     fs.writeFileSync(destMapHtml + 'head.html', $("head").html())
     fs.writeFileSync(destMapHtml + 'footer.html', $("footer").html())
-    fs.writeFileSync(destMapHtml + 'scripts.html', $.html($("script", 'body')))
+    fs.writeFileSync(destMapHtml + 'scripts.html', $.html($("#dpga-libs-js")) + $.html($("#dpga-main-js"))) // finds specific dpga scripts.
     fs.writeFileSync(destMapHtml + 'navbar.html', $("#page").html())
     fs.writeFileSync(destMapHtml + 'templateClassName.txt', $("body").attr('class'))
   });    


### PR DESCRIPTION
I found that the automation script keeps all `<script>`  files from previous versions of map. You can open [inspector ](https://digitalpublicgoods.net/map/) and find that there are more than 500 `<script>` nodes.
It ruins functionality of the map. Instead it supposed to keep in cycle only two `<script>` elements with ids `#dpga-libs-js` and `#dpga-main-js`.

This PR fixes that issue. Apologies that I didn't noticed that earlier.
@lacabra kindly review this PR. And I guess we need to rebuild digitalpublicgoods.net/map/ [index file](https://github.com/unicef/publicgoods-website/blob/main/map/index.html) from scratch to avoid errors.